### PR TITLE
when retrieving word from API, force all letters to lowercase

### DIFF
--- a/hangman.ps1
+++ b/hangman.ps1
@@ -88,7 +88,7 @@ function getWord() {
     
     try {
         $response = Invoke-RestMethod $url -Method Get -Headers $headers
-        $word = $response.word
+        $word = $response.word.ToLower()
 
         return $word
 


### PR DESCRIPTION
Some words come down with uppercase letters. Force target word to lowercase.